### PR TITLE
Add websocket port and domain name variable

### DIFF
--- a/cheesemarathon/Bitwarden.xml
+++ b/cheesemarathon/Bitwarden.xml
@@ -21,12 +21,17 @@
                 <ContainerPort>80</ContainerPort>
                 <Protocol>tcp</Protocol>
             </Port>
+            <Port>
+                <HostPort>3012</HostPort>
+                <ContainerPort>3012</ContainerPort>
+                <Protocol>tcp</Protocol>
+            </Port>
         </Publish>
     </Networking>
     <Data>
         <Volume>
-            <HostDir>/mnt/user/appdata/bitwarden/</HostDir>
-            <ContainerDir>/data/</ContainerDir>
+            <HostDir>/mnt/user/appdata/bitwarden</HostDir>
+            <ContainerDir>/data</ContainerDir>
             <Mode>rw</Mode>
         </Volume>
     </Data>
@@ -36,10 +41,17 @@
           <Name>SIGNUPS_ALLOWED</Name>
           <Mode/>
         </Variable>
+        <Variable>
+          <Value></Value>
+          <Name>DOMAIN</Name>
+          <Mode/>
+    	</Variable>
     </Environment>
-    <WebUI>http://[IP]:[PORT:8343]</WebUI>
+    <WebUI>http://[IP]:[PORT:80]</WebUI>
     <Icon>https://raw.githubusercontent.com/cheesemarathon/docker-templates/master/images/bitwarden.png</Icon>
-    <Config Name="WebUI" Target="80" Default="" Mode="tcp" Description="Container Port: 80" Type="Port" Display="always" Required="false" Mask="false">8343</Config>
-    <Config Name="App Data" Target="/data/" Default="" Mode="rw" Description="Container Path: /data/" Type="Path" Display="always" Required="false" Mask="false">/mnt/user/appdata/bitwarden/</Config>
-    <Config Name="SIGNUPS_ALLOWED" Target="SIGNUPS_ALLOWED" Default="true" Mode="" Description="Set to false to disable signups" Type="Variable" Display="always" Required="false" Mask="false">true</Config>
+    <Config Name="WebUI" Target="80" Default="" Mode="tcp" Description="Webui Port: 80" Type="Port" Display="always" Required="false" Mask="false">8343</Config>
+    <Config Name="WebSocket" Target="3012" Default="" Mode="tcp" Description="Websocket Port: 3012" Type="Port" Display="always" Required="false" Mask="false">3012</Config>
+    <Config Name="Appdata" Target="/data" Default="" Mode="rw" Description="Container Path: /data" Type="Path" Display="always" Required="false" Mask="false">/mnt/user/appdata/bitwarden</Config>
+    <Config Name="External Domain Name" Target="DOMAIN" Default="" Mode="" Description="In the format https://(subdomain).domain.com" Type="Variable" Display="always" Required="false" Mask="false"></Config>
+    <Config Name="Allow signups" Target="SIGNUPS_ALLOWED" Default="true" Mode="" Description="Set to false to disable signups" Type="Variable" Display="always" Required="false" Mask="false">true</Config>
 </Container>


### PR DESCRIPTION
Missing websocket port and domain name variable, added.  Change `WebUI` parameter to `http://[IP]:[PORT:80]` as Unraid will automatically redirect to appropriate host port if user changes it from default 8343.

